### PR TITLE
30 bug image upload not working

### DIFF
--- a/src/pages/create/CreateNamePage.tsx
+++ b/src/pages/create/CreateNamePage.tsx
@@ -1,13 +1,13 @@
-import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import GroupProfileDefault from "@/assets/icons/group-profile-default.webp";
+import Button from "@/components/button/Button";
+import Input from "@/components/input/Input";
 import {
   GROUP_CREATION_NAME_ANIMATION_CONTAINER_VARIANT as CONTAINER_VARIANT,
   GROUP_CREATION_NAME_ANIMATION_ITEM_VARIANT as ITEM_VARIANT,
 } from "@/pages/create/animations/animations";
-import GroupProfileDefault from "@/assets/icons/group-profile-default.webp";
-import Button from "@/components/button/Button";
-import Input from "@/components/input/Input";
 import Path from "@/types/paths";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import useGroupProfileSequence from "./hooks/useGroupProfileSequence";
@@ -83,8 +83,13 @@ const CreateGroupSequenceName = () => {
                   className={"mx-5 object-cover aspect-square rounded-full"}
                 />
 
-                <motion.label variants={ITEM_VARIANT}>
+                <motion.label
+                  variants={ITEM_VARIANT}
+                  className={"cursor-pointer"}
+                  htmlFor={"group-profile-image"}
+                >
                   <motion.input
+                    id={"group-profile-image"}
                     type={"file"}
                     accept={"image/*"}
                     onChange={(e) => {
@@ -96,11 +101,14 @@ const CreateGroupSequenceName = () => {
                     className={"hidden"}
                   />
 
-                  <motion.div>
-                    <Button variant="contained" size="big">
-                      {t("createGroup.name.chooseGroupProfile")}
-                    </Button>
-                  </motion.div>
+                  <motion.span
+                    className={
+                      "border border-primary text-primary hover:bg-secondary px-[25px] py-[10px] rounded-[5px]"
+                      // same as Button component's "outlined" variant. Need some kind of style injection
+                    }
+                  >
+                    {t("createGroup.name.chooseGroupProfile")}
+                  </motion.span>
                 </motion.label>
               </motion.div>
 

--- a/src/pages/create/CreateNotionPage.tsx
+++ b/src/pages/create/CreateNotionPage.tsx
@@ -64,13 +64,19 @@ const CreateNotionPage = () => {
 
       const groupUuid = response.uuid;
 
-      const image = await dataUrlToFile(
-        location.state.profileImageUrl,
-        "image",
-      );
+      try {
+        const filename = `profile_${Date.now()}`;
+        const image = await dataUrlToFile(
+          location.state.profileImageUrl,
+          filename,
+        );
 
-      if (groupUuid && location.state.profileImageUrl) {
-        await setGroupProfileImage(groupUuid, image);
+        if (groupUuid && location.state.profileImageUrl) {
+          await setGroupProfileImage(groupUuid, image);
+        }
+      } catch (error) {
+        console.error("profile image upload failed:", error);
+        // TODO: 사용자에게 이미지 업로드 실패 알림
       }
 
       setTimeout(() => {

--- a/src/pages/create/CreateNotionPage.tsx
+++ b/src/pages/create/CreateNotionPage.tsx
@@ -7,13 +7,14 @@ import { Trans, useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import useGroupNotionSequence from "./hooks/useGroupNotionSequence";
 
+import { createGroup, setGroupProfileImage } from "@/apis/group";
 import Button from "@/components/button/Button";
 import {
   GROUP_CREATION_NAME_ANIMATION_CONTAINER_VARIANT as CONTAINER_VARIANT,
   GROUP_CREATION_NAME_ANIMATION_ITEM_VARIANT as ITEM_VARIANT,
 } from "@/pages/create/animations/animations";
+import { dataUrlToFile } from "@/utils/dataURLtoFile";
 import { NotionRenderer } from "react-notion-x";
-import { createGroup, setGroupProfileImage } from "@/apis/group";
 
 const CreateNotionPage = () => {
   const { t } = useTranslation();
@@ -63,8 +64,13 @@ const CreateNotionPage = () => {
 
       const groupUuid = response.uuid;
 
+      const image = await dataUrlToFile(
+        location.state.profileImageUrl,
+        "image",
+      );
+
       if (groupUuid && location.state.profileImageUrl) {
-        await setGroupProfileImage(groupUuid, location.state.profileImageUrl);
+        await setGroupProfileImage(groupUuid, image);
       }
 
       setTimeout(() => {

--- a/src/pages/create/hooks/useGroupProfileSequence.tsx
+++ b/src/pages/create/hooks/useGroupProfileSequence.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
-import useDebouncedState from "@/hooks/useDebouncedState";
 import { checkGroupExistsByName } from "@/apis/group";
+import useDebouncedState from "@/hooks/useDebouncedState";
 
 const useGroupProfileSequence = () => {
   const [debouncedName, setName, name] = useDebouncedState<string>("");

--- a/src/pages/detail/GroupProfile.tsx
+++ b/src/pages/detail/GroupProfile.tsx
@@ -13,7 +13,8 @@ const GroupProfile = ({ group }: GroupProfileProps) => {
   return (
     <div className={"flex items-center gap-[25px]"}>
       <img
-        src={GroupProfileDefault}
+        src={group.profileImageUrl || GroupProfileDefault}
+        className={"rounded-full aspect-square object-cover"}
         width={160}
         height={160}
         alt={"group default profile"}

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -16,7 +16,8 @@ export interface GroupInfo {
   verifiedAt: dayjs.Dayjs | string;
   notionPageId: string;
   presidentUuid: string;
-  profileImageKey: string;
+  profileImageKey: string | null;
+  profileImageUrl: string | null;
   president: UserInfo;
   memberCount: number;
   notionPageId: string;

--- a/src/utils/dataURLtoFile/index.ts
+++ b/src/utils/dataURLtoFile/index.ts
@@ -2,7 +2,26 @@ export async function dataUrlToFile(
   dataUrl: string,
   fileName: string,
 ): Promise<File> {
-  const res: Response = await fetch(dataUrl);
-  const blob: Blob = await res.blob();
-  return new File([blob], fileName, { type: "image/png" });
+  if (!dataUrl?.trim()) {
+    throw new Error("Invalid dataUrl.");
+  }
+  if (!fileName?.trim()) {
+    throw new Error("Invalid fileName.");
+  }
+  try {
+    const res: Response = await fetch(dataUrl);
+    if (!res.ok) {
+      throw new Error("Failed to fetch the image.");
+    }
+    const blob: Blob = await res.blob();
+    return new File([blob], fileName, { type: "image/png" });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(
+        `An error occurred during file conversion: ${error.message}`,
+      );
+    } else {
+      throw new Error("An unknown error occurred during file conversion.");
+    }
+  }
 }

--- a/src/utils/dataURLtoFile/index.ts
+++ b/src/utils/dataURLtoFile/index.ts
@@ -1,0 +1,8 @@
+export async function dataUrlToFile(
+  dataUrl: string,
+  fileName: string,
+): Promise<File> {
+  const res: Response = await fetch(dataUrl);
+  const blob: Blob = await res.blob();
+  return new File([blob], fileName, { type: "image/png" });
+}


### PR DESCRIPTION
label을 클릭하면 안에 있는 input이 자동으로 클릭될 줄 알았는데 button이 있는 경우에는 버튼이 이벤트를 가로채는 것 같더라구요. button을 span으로 변경했습니다.

이미지 업로드 시 File Object를 보내야 하는데 location.state 특성상 string 데이터밖에 전송하지 못하는 문제가 있었습니다. 그래서 base64 string 형식의 이미지를 file object로 변경해서 보내는 로직을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 그룹 프로필 이미지 처리 개선.
	- 이미지 URL을 파일 객체로 변환하는 새로운 기능 추가.
  
- **버그 수정**
	- 프로필 이미지 URL이 없을 경우 기본 이미지로 대체하는 로직 개선.

- **문서화**
	- `GroupInfo` 인터페이스에 `profileImageUrl` 속성 추가 및 `profileImageKey` 속성의 타입 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->