### PR TITLE
:lipstick: Seperate loading and error

### DIFF
--- a/src/locales/en-US/index.ts
+++ b/src/locales/en-US/index.ts
@@ -115,6 +115,9 @@ export const main = {
       notices: "Notices",
       members: "Members",
     },
+    intro: {
+      notExist: "The group introduction page does not exist yet.",
+    },
   },
   groupInvitation: {
     title: "Group Member Invitation Link",
@@ -216,12 +219,14 @@ export const main = {
       },
       groupDelete: {
         title: "Delete Group",
-        description: "Notices posted under this group name will not be affected. This action cannot be undone.",
+        description:
+          "Notices posted under this group name will not be affected. This action cannot be undone.",
         button: "Delete",
       },
       groupLeave: {
         title: "Leave Group",
-        description: "Notices posted under this group name will not be affected. You can rejoin if invited again after leaving the group.",
+        description:
+          "Notices posted under this group name will not be affected. You can rejoin if invited again after leaving the group.",
         button: "Leave",
       },
       complete: "Complete",
@@ -230,7 +235,8 @@ export const main = {
       name: "Notion Link",
       title: "Group Introduction Notion Link",
       description: {
-        first: "You can attach your beautiful Notion link to the group introduction.",
+        first:
+          "You can attach your beautiful Notion link to the group introduction.",
         second: "After publishing your group introduction Notion on the web,",
         third: "please paste the link here.",
       },
@@ -259,15 +265,18 @@ export const main = {
         title: "💡 Member Roles",
         admin: {
           title: "Admin",
-          description: "Has all permissions, including editing group info, changing roles, and expelling members.",
+          description:
+            "Has all permissions, including editing group info, changing roles, and expelling members.",
         },
         manager: {
           title: "Manager",
-          description: "Can invite members and post notices on behalf of the group.",
+          description:
+            "Can invite members and post notices on behalf of the group.",
         },
         normal: {
           title: "Normal",
-          description: "Can only leave the group but is displayed as a group member on the group intro page.",
+          description:
+            "Can only leave the group but is displayed as a group member on the group intro page.",
         },
       },
       complete: "Complete",

--- a/src/locales/ko-KR/index.ts
+++ b/src/locales/ko-KR/index.ts
@@ -106,6 +106,9 @@ export const main = {
       notices: "공지",
       members: "멤버",
     },
+    intro: {
+      notExist: "아직 소개 페이지가 없습니다.",
+    },
   },
   groupInvitation: {
     title: "그룹 멤버 초대 링크",
@@ -206,12 +209,14 @@ export const main = {
       },
       groupDelete: {
         title: "그룹 삭제",
-        description: "기존에 본 그룹 명의로 작성된 공지에는 영향을 끼치지 않습니다. 본 작업은 되돌릴 수 없습니다.",
+        description:
+          "기존에 본 그룹 명의로 작성된 공지에는 영향을 끼치지 않습니다. 본 작업은 되돌릴 수 없습니다.",
         button: "삭제하기",
       },
       groupLeave: {
         title: "그룹 나가기",
-        description: "기존에 본 그룹 명의로 작성된 공지에는 영향을 끼치지 않습니다. 그룹을 나간 뒤에도 초대된다면 다시 그룹에 참여할 수 있습니다.",
+        description:
+          "기존에 본 그룹 명의로 작성된 공지에는 영향을 끼치지 않습니다. 그룹을 나간 뒤에도 초대된다면 다시 그룹에 참여할 수 있습니다.",
         button: "나가기",
       },
       complete: "완료",
@@ -249,7 +254,8 @@ export const main = {
         title: "💡 멤버 역할",
         admin: {
           title: "관리자",
-          description: "그룹 정보 수정, 멤버 역할 변경, 추방 등 모든 권한을 가집니다.",
+          description:
+            "그룹 정보 수정, 멤버 역할 변경, 추방 등 모든 권한을 가집니다.",
         },
         manager: {
           title: "매니저",
@@ -257,7 +263,8 @@ export const main = {
         },
         normal: {
           title: "일반",
-          description: "그룹 나가기의 권한만 가집니다. 단, 그룹 소개 페이지에서 그룹의 일원으로 표시됩니다.",
+          description:
+            "그룹 나가기의 권한만 가집니다. 단, 그룹 소개 페이지에서 그룹의 일원으로 표시됩니다.",
         },
       },
       complete: "완료",

--- a/src/pages/detail/DetailPage.tsx
+++ b/src/pages/detail/DetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import useSWR from "swr";
 
@@ -6,12 +6,12 @@ import { getGroup } from "@/apis/group";
 
 import GroupDetailTabs from "./GroupDetailTabs";
 
+import Card from "@/components/card/Card";
+import Loading from "@/components/loading/Loading";
+import GroupProfile from "./GroupProfile";
+import GroupIntroTab from "./tabs/intro/GroupIntroTab";
 import GroupMembersTab from "./tabs/members/GroupMembersTab";
 import GroupNoticesTab from "./tabs/notices/GroupNoticesTab";
-import GroupIntroTab from "./tabs/intro/GroupIntroTab";
-import GroupProfile from "./GroupProfile";
-import Loading from "@/components/loading/Loading";
-import Card from "@/components/card/Card";
 
 interface GroupDetailPageProps {
   searchParams?: { tab: string; page: string };
@@ -21,7 +21,6 @@ const GroupDetailPage = ({ searchParams }: GroupDetailPageProps) => {
   const { uuid } = useParams<{ uuid: string }>();
 
   const { data: group } = useSWR(uuid, getGroup);
-
 
   const [tab, setTab] = useState("info");
 

--- a/src/pages/detail/tabs/intro/GroupIntroTab.tsx
+++ b/src/pages/detail/tabs/intro/GroupIntroTab.tsx
@@ -8,23 +8,29 @@ import "./styles.css";
 
 import { getGroup } from "@/apis/group";
 import { getNotionPage } from "@/apis/notion";
+import Card from "@/components/card/Card";
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import useSWR from "swr";
 import NotionWrapper from "./NotionWrapper";
 //import NotionWrapper from "./NotionWrapper";
 const GroupIntroTab = () => {
   const { uuid } = useParams();
-  const { data: group, error: groupError } = useSWR(uuid, getGroup);
+  const { data: group, error: groupError, isLoading } = useSWR(uuid, getGroup);
   const { data: recordMap, error: recordMapError } = useSWR(
     group && group.notionPageId,
     getNotionPage,
   );
+  const { t } = useTranslation();
 
   if (groupError) return <div>Group introduce page not found</div>;
   if (recordMapError)
     return <div>Notion page not found - Please Check your notion ID</div>;
 
-  if (!group || !recordMap) return <div>Loading...</div>; // TODO: Add loading UI
+  if (isLoading) return <Card className={"mt-5"}>Loading...</Card>; // TODO: Add loading UI
+
+  if (!group || !recordMap)
+    return <Card className={"mt-5"}>{t("group.intro.notExist")}</Card>;
 
   return (
     <div className={"mt-5"}>

--- a/src/pages/detail/tabs/members/GroupMembersTab.tsx
+++ b/src/pages/detail/tabs/members/GroupMembersTab.tsx
@@ -4,8 +4,11 @@ import useSWR from "swr";
 
 const GroupMembersTab = () => {
   const { data, error, isLoading } = useSWR("UserInfo", getUserInfo);
-  if (error || isLoading) {
+  if (isLoading) {
     return <Card className={"mt-6"}>Loading members...</Card>;
+  }
+  if (error) {
+    return <Card className={"mt-6"}>Failed to load members.</Card>;
   }
   return (
     <div className="flex flex-col items-center">

--- a/src/pages/detail/tabs/members/GroupMembersTab.tsx
+++ b/src/pages/detail/tabs/members/GroupMembersTab.tsx
@@ -1,23 +1,27 @@
 import { getUserInfo } from "@/apis/auth";
+import Card from "@/components/card/Card";
 import useSWR from "swr";
 
-
 const GroupMembersTab = () => {
-  const {data, error, isLoading} = useSWR("UserInfo",getUserInfo)
-  if(error || isLoading){
-    return <p>Loading members...</p>
+  const { data, error, isLoading } = useSWR("UserInfo", getUserInfo);
+  if (error || isLoading) {
+    return <Card className={"mt-6"}>Loading members...</Card>;
   }
-  return <div className="flex flex-col items-center">
-    <div className={"flex items-center justify-between my-6 w-2/3 rounded-2xl bg-greyLight px-5 py-[15px] text-lg text-greyDark"}>
-      <div>
-        <p>{data?.name}</p>
-        <p>{data?.email}</p>
-      </div>
-      <div>
-        Admin
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className={
+          "flex items-center justify-between my-6 w-2/3 rounded-2xl bg-greyLight px-5 py-[15px] text-lg text-greyDark"
+        }
+      >
+        <div>
+          <p>{data?.name}</p>
+          <p>{data?.email}</p>
+        </div>
+        <div>Admin</div>
       </div>
     </div>
-  </div>;
+  );
 };
 
 export default GroupMembersTab;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/98448b6f-dcf2-45f9-9871-ad11ab660c1d)

소개탭이랑 멤버탭 로딩 UI 개선 &  로딩 상태와 not exist 상태 구분

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 그룹 소개 페이지에 대한 현지화 메시지 추가
	- 그룹 소개 탭에 로딩 상태 및 오류 처리 개선

- **버그 수정**
	- 그룹 소개 및 멤버 탭의 로딩 상태 표시 개선

- **스타일**
	- 로딩 및 오류 메시지에 Card 컴포넌트 적용
	- 현지화 문자열의 가독성 향상을 위한 포맷팅 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->