### PR TITLE
fix: show profile image on GroupItem

### DIFF
--- a/src/pages/main/GroupItem.tsx
+++ b/src/pages/main/GroupItem.tsx
@@ -17,14 +17,14 @@ const GroupItem = ({
 }) => {
   const group = groupParams.group;
   const { userInfo } = useAuth();
-
+  
   const isPresident = userInfo?.uuid === group.presidentUuid;
 
   return (
     <Card>
       <a href={`/group/${group.uuid}`} className={"flex items-center"}>
         <img
-          src={GroupProfileDefault}
+          src={group.profileImageUrl || GroupProfileDefault}
           alt="group-default-profile"
           width={40}
           height={40}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 그룹 프로필 이미지 표시 로직이 개선되어, 설정된 프로필 이미지가 있을 경우 우선적으로 적용되고, 그렇지 않으면 기본 이미지가 표시됩니다.
	- 코드 가독성을 높이기 위한 사소한 형식 수정이 이루어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->