### PR TITLE
87 feat make member role when invited

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,10 @@ const router = createBrowserRouter(
           <Route path={Path.GroupNotices} element={<GroupNoticesTab />} />
           <Route path={Path.GroupMembers} element={<GroupMembersTab />} />
         </Route>
-        <Route path={Path.Invite + ":code" } element={<InvitePage />} />
+        <Route
+          path={Path.Invite + ":code" + "/" + ":groupId"}
+          element={<InvitePage />}
+        />
 
         <Route element={<CreateGroupLayout />}>
           <Route

--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -154,3 +154,9 @@ export const createRole = async (
       console.log(`Default role ${roleName} set successfully.`);
     });
 };
+
+export const getRoles = async (groupUuid: string) => {
+  return groupsApi
+    .get(`/group/${groupUuid}/role`)
+    .then(({data})=> data)
+}

--- a/src/apis/group.ts
+++ b/src/apis/group.ts
@@ -29,9 +29,10 @@ export interface InviteCode {
 export const generateInviteCode = async (
   uuid: string,
   duration: number,
+  roleId: number,
 ): Promise<InviteCode> => {
   return groupsApi
-    .post<InviteCode>(`/group/${uuid}/invite?duration=${duration}`)
+    .post<InviteCode>(`/group/${uuid}/invite?duration=${duration}&roleId=${roleId}`)
     .then(({ data }) => data);
 };
 
@@ -126,9 +127,10 @@ export const grantMemberRole = async (
   roleChange: number[],
 ): Promise<void> => {
   try {
-    await groupsApi.delete(
-      `/group/${groupUuid}/member/${memberUuid}/role?roleId=${roleChange[0]}`,
-    );
+    if (roleChange[0] !== 0)
+      await groupsApi.delete(
+        `/group/${groupUuid}/member/${memberUuid}/role?roleId=${roleChange[0]}`,
+      );
     return groupsApi.patch(
       `/group/${groupUuid}/member/${memberUuid}/role?roleId=${roleChange[1]}`,
     );

--- a/src/pages/createGroup/pages/complete/GenerateInvitationLink.tsx
+++ b/src/pages/createGroup/pages/complete/GenerateInvitationLink.tsx
@@ -62,6 +62,7 @@ const GenerateInvitationLink = ({ groupUuid }: GenerateInvitationLinkProps) => {
       generateInviteCode(
         groupUuid,
         expirationOption.expirationTime * A_DAY_SECOND,
+        3
       ),
   );
 

--- a/src/pages/createGroup/pages/complete/GenerateInvitationLink.tsx
+++ b/src/pages/createGroup/pages/complete/GenerateInvitationLink.tsx
@@ -62,7 +62,7 @@ const GenerateInvitationLink = ({ groupUuid }: GenerateInvitationLinkProps) => {
       generateInviteCode(
         groupUuid,
         expirationOption.expirationTime * A_DAY_SECOND,
-        3
+        3,
       ),
   );
 
@@ -70,7 +70,7 @@ const GenerateInvitationLink = ({ groupUuid }: GenerateInvitationLinkProps) => {
 
   useEffect(() => {
     if (!data) return;
-    setInvitationLink(invitationLinkGenerator(data.code,groupUuid));
+    setInvitationLink(invitationLinkGenerator(data.code, groupUuid));
   }, [data]);
 
   const [isCopyAnimationPlay, setIsCopyAnimationPlay] = useState(false);

--- a/src/pages/createGroup/pages/complete/GenerateInvitationLink.tsx
+++ b/src/pages/createGroup/pages/complete/GenerateInvitationLink.tsx
@@ -69,7 +69,7 @@ const GenerateInvitationLink = ({ groupUuid }: GenerateInvitationLinkProps) => {
 
   useEffect(() => {
     if (!data) return;
-    setInvitationLink(invitationLinkGenerator(data.code));
+    setInvitationLink(invitationLinkGenerator(data.code,groupUuid));
   }, [data]);
 
   const [isCopyAnimationPlay, setIsCopyAnimationPlay] = useState(false);

--- a/src/pages/createGroup/utils/invitationLinkGenerator.ts
+++ b/src/pages/createGroup/utils/invitationLinkGenerator.ts
@@ -1,5 +1,5 @@
-const invitationLinkGenerator = (code: string) => {
-  return import.meta.env.VITE_BASE_URL + "invite" + "?code=" + code;
+const invitationLinkGenerator = (code: string,groupId:string) => {
+  return `${import.meta.env.VITE_BASE_URL}invite/${code}/${groupId}`;
 };
 
 export default invitationLinkGenerator;

--- a/src/pages/invite/InvitePage.tsx
+++ b/src/pages/invite/InvitePage.tsx
@@ -3,7 +3,10 @@ import JoinGroupAnimation from "@/assets/animations/JoinGroup.json";
 import Lottie from "lottie-react";
 import useSWR from "swr";
 import apiKeys from "@/types/api-keys";
-import { createRole, getInvitationInfoByInvitationCode, joinGroup } from "@/apis/group";
+import {
+  getInvitationInfoByInvitationCode,
+  joinGroup,
+} from "@/apis/group";
 import { Trans, useTranslation } from "react-i18next";
 import Button from "@/components/button/Button";
 import Path from "@/types/paths";
@@ -13,11 +16,11 @@ import { isAxiosError } from "axios";
 import Error from "@/assets/error/Error";
 
 const InvitePage = () => {
-  const {code, groupId} = useParams()
+  const { code, groupId } = useParams();
   const navigator = useNavigate();
-  console.log(groupId)
+
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
- 
+
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -39,7 +42,6 @@ const InvitePage = () => {
 
     try {
       await joinGroup(code);
-      // await createRole
       navigator(Path.Home, {
         state: {
           joinedGroupName: data.name,

--- a/src/pages/invite/InvitePage.tsx
+++ b/src/pages/invite/InvitePage.tsx
@@ -3,7 +3,7 @@ import JoinGroupAnimation from "@/assets/animations/JoinGroup.json";
 import Lottie from "lottie-react";
 import useSWR from "swr";
 import apiKeys from "@/types/api-keys";
-import { getInvitationInfoByInvitationCode, joinGroup } from "@/apis/group";
+import { createRole, getInvitationInfoByInvitationCode, joinGroup } from "@/apis/group";
 import { Trans, useTranslation } from "react-i18next";
 import Button from "@/components/button/Button";
 import Path from "@/types/paths";
@@ -13,9 +13,9 @@ import { isAxiosError } from "axios";
 import Error from "@/assets/error/Error";
 
 const InvitePage = () => {
-  const {code} = useParams()
+  const {code, groupId} = useParams()
   const navigator = useNavigate();
-  
+  console.log(groupId)
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
  
   const { t } = useTranslation();
@@ -39,6 +39,7 @@ const InvitePage = () => {
 
     try {
       await joinGroup(code);
+      // await createRole
       navigator(Path.Home, {
         state: {
           joinedGroupName: data.name,
@@ -122,5 +123,4 @@ const InvitePage = () => {
     </>
   );
 };
-
 export default InvitePage;

--- a/src/pages/invite/InvitePage.tsx
+++ b/src/pages/invite/InvitePage.tsx
@@ -16,7 +16,7 @@ import { isAxiosError } from "axios";
 import Error from "@/assets/error/Error";
 
 const InvitePage = () => {
-  const { code, groupId } = useParams();
+  const { code } = useParams();
   const navigator = useNavigate();
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/src/pages/manage/pages/members/component/InviteSection.tsx
+++ b/src/pages/manage/pages/members/component/InviteSection.tsx
@@ -28,6 +28,7 @@ const InviteSection = () => {
         const data = await generateInviteCode(
           group.uuid,
           selectedOption.id * 86400,
+          3,  
         );
         const link = `${import.meta.env.VITE_BASE_URL}invite/${data.code}/${group.uuid}`;
         setInviteLink(link);

--- a/src/pages/manage/pages/members/component/InviteSection.tsx
+++ b/src/pages/manage/pages/members/component/InviteSection.tsx
@@ -29,7 +29,7 @@ const InviteSection = () => {
           group.uuid,
           selectedOption.id * 86400,
         );
-        const link = `${import.meta.env.VITE_BASE_URL}invite/${data.code}`;
+        const link = `${import.meta.env.VITE_BASE_URL}invite/${data.code}/${group.uuid}`;
         setInviteLink(link);
       } catch (error) {
         console.error("링크 생성 실패:", error);


### PR DESCRIPTION
- 초대 링크를 생성 할 때부터 query로 roleId를 넣어서 초대된 사람이 member role을 가지도록 벡엔드를 바꾸었음
- 그런데 막상 roleId=3으로 요청을 보내면 Admin으로 설정됨
- 혹시 role이 생성되지 않았나 싶어서 group의 role을 보니까 getGroupRole을 실행해보니까 member와 manager가 없었음
- 그럼 그룹 생성할 때 createRole이 잘못되었구나 싶어서 봤는데 문제가 없음
- 그리고 group role이 존재하지 않는데, 그룹 관리 페이지에서 멤버의 role을 변경하는 grant a role은 정상작동함

=> 그냥 이상함 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 초대 페이지 경로가 업데이트되어 초대 링크에 그룹 식별자가 포함됩니다.
  - 초대 코드 생성 로직이 개선되어 역할 옵션이 함께 반영됩니다.
  - 그룹 역할 정보를 조회할 수 있는 기능이 추가되었습니다.
  - 초대 링크 생성 로직이 업데이트되어 그룹 UUID를 포함합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->