### PR TITLE
[BUGFIX] now send user group info page when click 'back' in group management page

### DIFF
--- a/src/pages/manage/ManageLayout.tsx
+++ b/src/pages/manage/ManageLayout.tsx
@@ -22,6 +22,8 @@ const ManageLayout = () => {
   const isAdmin = location.pathname.includes("admin");
   const isManager = location.pathname.includes("manager");
   const isMember = location.pathname.includes("member");
+  const userRole = isAdmin ? "admin" : isManager ? "manager" : "member";
+
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -36,11 +38,7 @@ const ManageLayout = () => {
   }, [uuid]);
 
   const handleGoBack = () => {
-    if (window.history.state && window.history.state.idx > 0) {
-      navigate(-1);
-    } else {
-      navigate(Path.Home);
-    }
+    navigate(`/group/${uuid}`);
   };
 
   if (!uuid) return <p>유효하지 않은 그룹입니다.</p>;
@@ -65,9 +63,7 @@ const ManageLayout = () => {
             <GroupHeader group={group} />
           </div>
           {/* 네비게이터 */}
-          <Navigator
-            role={isAdmin ? "admin" : isManager ? "manager" : "member"}
-          />
+          <Navigator role={userRole} />
         </div>
         {/* 개별 페이지의 콘텐츠 */}
         <Outlet context={{ group, setGroup }} />

--- a/src/pages/manage/ManageLayout.tsx
+++ b/src/pages/manage/ManageLayout.tsx
@@ -1,6 +1,12 @@
 import ArrowRight from "@/assets/icons/arrow-right.svg?react";
 import Path from "@/types/paths";
-import { Link, Outlet, useLocation, useParams } from "react-router-dom";
+import {
+  Link,
+  Outlet,
+  useLocation,
+  useParams,
+  useNavigate,
+} from "react-router-dom";
 import { useState, useEffect } from "react";
 import { getGroup } from "@/apis/group";
 import { GroupInfo } from "@/types/interfaces";
@@ -16,6 +22,7 @@ const ManageLayout = () => {
   const isAdmin = location.pathname.includes("admin");
   const isManager = location.pathname.includes("manager");
   const isMember = location.pathname.includes("member");
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (uuid) {
@@ -28,6 +35,14 @@ const ManageLayout = () => {
     }
   }, [uuid]);
 
+  const handleGoBack = () => {
+    if (window.history.state && window.history.state.idx > 0) {
+      navigate(-1);
+    } else {
+      navigate(Path.Home);
+    }
+  };
+
   if (!uuid) return <p>유효하지 않은 그룹입니다.</p>;
 
   if (loading) return <p>데이터를 불러오는 중...</p>;
@@ -39,14 +54,14 @@ const ManageLayout = () => {
         <div className="flex flex-col items-start gap-5 self-stretch">
           {/* 뒤로 가기 및 그룹 이름 */}
           <div className="flex flex-col items-start gap-2.5 self-stretch">
-            <Link to={Path.Home}>
+            <div onClick={handleGoBack} className="cursor-pointer">
               <div className="flex items-center">
                 <ArrowRight className="h-5 w-5 md:h-6 md:w-6 stroke-primary scale-x-[-1]" />
                 <p className="text-primary text-base md:text-xl font-medium">
                   {t("manageGroup.goBack")}
                 </p>
               </div>
-            </Link>
+            </div>
             <GroupHeader group={group} />
           </div>
           {/* 네비게이터 */}


### PR DESCRIPTION
resolve #95 
- 이제 뒤로 버튼을 누르면 그룹 정보 페이지로 보냅니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 그룹 페이지로 돌아가는 내비게이션이 개선되어, 사용자가 쉽게 이전 페이지로 이동할 수 있도록 새로운 클릭 기반 동작이 도입되었습니다.
  
- **Refactor**
  - 사용자 역할 확인 및 내비게이션 관련 로직이 재구성되어, 보다 명확하고 일관된 사용자 경험을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->