### PR TITLE
feat: show roleName in group list page

### DIFF
--- a/src/pages/main/GroupItem.tsx
+++ b/src/pages/main/GroupItem.tsx
@@ -1,13 +1,15 @@
 import { GroupInfoWithPresidentUuid } from "src/types/interfaces";
 
 import ArrowRight from "@/assets/icons/arrow-right.svg?react";
-import Crown from "@/assets/icons/crown.svg?react";
+import { Crown } from "iconoir-react";
 import Settings from "@/assets/icons/settings.svg?react";
 import GroupProfileDefault from "@/assets/icons/group-profile-default.webp";
 import Card from "@/components/card/Card";
 import { Link } from "react-router-dom";
 import useSWR from "swr";
 import { getUserRole } from "@/apis/group";
+import useAuth from "@/hooks/useAuth";
+import { cn } from "@/utils/clsx";
 
 const GroupItem = ({
   groupParams,
@@ -17,6 +19,7 @@ const GroupItem = ({
   };
 }) => {
   const group = groupParams.group;
+  const { userInfo } = useAuth();
 
   const { data: userRole } = useSWR(
     ["userRole", group.uuid || ""],
@@ -26,25 +29,33 @@ const GroupItem = ({
   if (!userRole) return <></>;
 
   const isAdmin = userRole.name === "admin";
+  const isManager = userRole.name === "manager";
+  const isPresident = userInfo?.uuid === group.presidentUuid;
+
+  const getCrownColor = () => {
+    if (isPresident) return "text-yellow-500";
+    if (isAdmin) return "text-slate-400";
+    if (isManager) return "text-amber-700";
+    return null;
+  };
+
+  const crownColor = getCrownColor();
 
   return (
     <Card>
       <a href={`/group/${group.uuid}`} className={"flex items-center"}>
-      <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
-        <img
-          src={group.profileImageUrl || GroupProfileDefault}
-          alt="group-default-profile"
-          className="w-full h-full object-cover" 
-        />
-      </div>
+        <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+          <img
+            src={group.profileImageUrl || GroupProfileDefault}
+            alt="group-default-profile"
+            className="w-full h-full object-cover"
+          />
+        </div>
 
-        <p className="ml-[15px] mr-[5px] text-lg font-semibold text-dark dark:text-d_white">
+        <p className="flex items-center gap-2 ml-[15px] mr-[5px] text-lg font-semibold text-dark dark:text-d_white">
           {group.name}
+          {crownColor && <Crown className={cn(crownColor)} />}
         </p>
-
-        {isAdmin && (
-          <Crown className="ml-1 inline stroke-dark dark:stroke-d_white" />
-        )}
 
         <div className="flex-grow" />
 

--- a/src/pages/manage/pages/members/sections/memberManagement/MemberTableRow.tsx
+++ b/src/pages/manage/pages/members/sections/memberManagement/MemberTableRow.tsx
@@ -63,7 +63,10 @@ const MemberTableRow = ({
       {/* 이름 */}
       <th className={cn(cellStyle, "text-greyDark")}>
         <div className="flex items-center gap-2">
-          {member.name} {isThisMemberPresident && <Crown />}
+          {member.name}
+          <div className="text-yellow-500">
+            {isThisMemberPresident && <Crown />}
+          </div>
         </div>
       </th>
       {/* 이메일 */}


### PR DESCRIPTION
1. 그룹 리스트
각 그룹 내 본인의 역할(roleName)에 따라 왕관 아이콘의 색상을 구분하여 표시하도록 변경했습니다.
 - 그룹장: 금색
 - 관리자: 은색
 - 매니저: 동색

<img width="986" height="320" alt="스크린샷 2026-01-09 122250" src="https://github.com/user-attachments/assets/43e6e2da-05f3-4a08-a85a-3a2572809c3f" />

2. 그룹 관리창 - 멤버 탭
기존에 회색으로 표시되던 그룹장의 왕관 아이콘을 그룹 리스트 디자인과 통일하기 위해 금색으로 변경했습니다.

구현 의도: 멤버 리스트에는 이미 역할(roleName)을 텍스트로 보여주는 열이 존재하므로, 시각적 중복을 피하기 위해 그룹장 외의 역할(관리자, 매니저)에는 별도의 왕관 아이콘을 추가하지 않았습니다.

<img width="1115" height="448" alt="스크린샷 2026-01-09 122456" src="https://github.com/user-attachments/assets/66b1dab8-aea8-4ed4-a15d-81ced7ce8bc5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

그룹 항목과 회원 목록의 사용자 역할 표시 기능을 개선했습니다.

* **Style**
  * 사용자 역할 및 권한에 따른 크라운 아이콘 색상 동적 적용
  * 그룹 항목과 회원 테이블의 레이아웃 및 스타일 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->